### PR TITLE
Fix Hyperparameter selection function interface

### DIFF
--- a/Task_1/openfl-workspace/fets_challenge_workspace/plan/plan.yaml
+++ b/Task_1/openfl-workspace/fets_challenge_workspace/plan/plan.yaml
@@ -95,6 +95,7 @@ task_runner :
         maximum: 0.0.14
         minimum: 0.0.14
       weighted_loss: true
+      test: true
 
 
 network :

--- a/Task_1/openfl-workspace/fets_challenge_workspace/plan/plan.yaml
+++ b/Task_1/openfl-workspace/fets_challenge_workspace/plan/plan.yaml
@@ -95,7 +95,6 @@ task_runner :
         maximum: 0.0.14
         minimum: 0.0.14
       weighted_loss: true
-      test: true
 
 
 network :

--- a/Task_1/openfl-workspace/fets_challenge_workspace/src/__init__.py
+++ b/Task_1/openfl-workspace/fets_challenge_workspace/src/__init__.py
@@ -1,10 +1,10 @@
 # Provided by the FeTS Initiative (www.fets.ai) as part of the FeTS Challenge 2021
 
 # Contributing Authors (alphabetical):
+# Patrick Foley (Intel)
 # Micah Sheller (Intel)
 
 TRAINING_HPARAMS = [
     'epochs_per_round',
-    'batches_per_round',
     'learning_rate',
 ]

--- a/Task_1/openfl-workspace/fets_challenge_workspace/src/fets_challenge_model.py
+++ b/Task_1/openfl-workspace/fets_challenge_workspace/src/fets_challenge_model.py
@@ -138,7 +138,6 @@ class FeTSChallengeModel(FeTSChallengeTaskRunner):
             local_output_dict       : Tensors to maintain in the local TensorDB
         """
 
-        print(f'input tensor_dict = {input_tensor_dict.keys()}')
         # handle the hparams
         epochs_per_round = int(input_tensor_dict.pop('epochs_per_round'))
         learning_rate = float(input_tensor_dict.pop('learning_rate'))


### PR DESCRIPTION
This PR:
- Fixes the hyperparameter selection function interface
- Removes `batches_per_round` from the hyperparameter function selection return statement. Function interface now must return (`learning_rate`,`epochs_per_round`), where epochs is an `int`.  